### PR TITLE
Add to_carbon function to helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -874,7 +874,46 @@ if (! function_exists('storage_path')) {
         return app('path.storage').($path ? DIRECTORY_SEPARATOR.$path : $path);
     }
 }
+if ( ! function_exists( 'to_carbon' ))
+{
+	function to_carbon($value, $alternateFormat = null, $defaultTime = null)
+	{
+		// If it's already a Carbon object, return it.
+		if ($value instanceof Carbon\Carbon)
+		{
+			return $value;
+		}
 
+		// If this value is an integer, we will assume it is a UNIX timestamp's value
+		// and format a Carbon object from this timestamp. This allows flexibility
+		// when defining your date fields as they might be UNIX timestamps here.
+		if (is_numeric($value))
+		{
+			return Carbon\Carbon::createFromTimestamp($value);
+		}
+
+		$value = str_replace('/', '-', $value);
+
+		$value = str_replace('\\', '-', $value);
+
+		// Try to convert it using strtotime().
+		if (($date = strtotime($value)) !== false)
+		{
+			return Carbon\Carbon::createFromTimestamp($date);
+		}
+
+		// Finally, we will just assume this date is in the format passed as parameter
+		// or we will try to use a default format.
+		elseif ( ! $value instanceof DateTime)
+		{
+			$alternateFormat = $alternateFormat ?: 'Y-m-d H:i:s';
+
+			return Carbon\Carbon::createFromFormat($alternateFormat, $value);
+		}
+
+		return Carbon\Carbon::instance($value);
+	}
+}
 if (! function_exists('today')) {
     /**
      * Create a new Carbon instance for the current date.


### PR DESCRIPTION
In the same idea as the `now()` , `today()` helpers, this function is a shortcut way to convert any string/timestamp date to a carbon instance. It has some built in formats detection.

Credits to https://github.com/antonioribeiro 
Source: https://github.com/antonioribeiro/support/blob/master/src/helpers.php

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
